### PR TITLE
[RFC] Change `Service` associated `Request` type to a type parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-metrics 0.1.0",
- "linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)",
+ "linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)",
  "linkerd2-proxy-router 0.1.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,8 +538,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service#b639b0d0c4dcc8427bb731613379efa6ef680b2d"
+version = "0.1.1"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service#e2747848857fcdd391dbb9a04e4cebae7f4373e1"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#31ace5d078294399d18a1eb1f71e15c2ed8a1e40"
+source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#14ca7da5bc50e623f1b848ccf8c7815739f48686"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#31ace5d078294399d18a1eb1f71e15c2ed8a1e40"
+source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#14ca7da5bc50e623f1b848ccf8c7815739f48686"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1627,7 +1627,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-metrics 0.1.0",
- "linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1)",
+ "linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)",
  "linkerd2-proxy-router 0.1.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -519,17 +519,17 @@ dependencies = [
  "tokio-rustls 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
- "tower-h2-balance 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
- "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http?branch=eliza/generic-service)",
+ "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
+ "tower-h2-balance 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
+ "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-util 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
  "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,8 +538,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.1"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1#b0543809839fd0e6bc7cb8e4a644ce48df88b27d"
+version = "0.1.0"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service#b639b0d0c4dcc8427bb731613379efa6ef680b2d"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -549,9 +549,9 @@ dependencies = [
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
+ "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)",
+ "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
 ]
 
 [[package]]
@@ -1235,11 +1235,25 @@ dependencies = [
 [[package]]
 name = "tower-add-origin"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#c9e13f641a681b3ef01e96910789586e39aee2e2"
+source = "git+https://github.com/tower-rs/tower-http?branch=eliza/generic-service#c7cd0ffe4353bf1601f159ade696f238f291bf88"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+]
+
+[[package]]
+name = "tower-balance"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
@@ -1259,10 +1273,19 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+]
+
+[[package]]
+name = "tower-discover"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
@@ -1277,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#0afac3d409febe20db4432b5abe06dbd72bd4c95"
+source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#31ace5d078294399d18a1eb1f71e15c2ed8a1e40"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1285,14 +1308,14 @@ dependencies = [
  "http 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#0afac3d409febe20db4432b5abe06dbd72bd4c95"
+source = "git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service#31ace5d078294399d18a1eb1f71e15c2ed8a1e40"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1302,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#1299be66fee7be919699d7c1edfb30adac03d4c1"
+source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#28c601909f5268d7fc042184a08f254e661e7c4a"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1311,39 +1334,47 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
 name = "tower-h2-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#760f9fc1c83c3a96edb6fbddb6b0cd3cac73d8ac"
+source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#28c601909f5268d7fc042184a08f254e661e7c4a"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1357,10 +1388,10 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
+source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
@@ -1627,7 +1658,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/generic-service)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -1703,18 +1734,21 @@ dependencies = [
 "checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
 "checksum tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "028b94314065b90f026a21826cffd62a4e40a92cda3e5c069cc7b02e5945f5e9"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
-"checksum tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
+"checksum tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http?branch=eliza/generic-service)" = "<none>"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
+"checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
-"checksum tower-h2-balance 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
-"checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
+"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)" = "<none>"
+"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)" = "<none>"
+"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)" = "<none>"
+"checksum tower-h2-balance 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)" = "<none>"
+"checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
+"checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
+"checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
 "checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,20 +1257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-balance"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
-dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
-]
-
-[[package]]
 name = "tower-buffer"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
@@ -1286,15 +1272,6 @@ source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
-dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
@@ -1325,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#28c601909f5268d7fc042184a08f254e661e7c4a"
+source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#cf5f5a08c2c69448d22f47436c52855747fcf74a"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,14 +1317,14 @@ dependencies = [
 [[package]]
 name = "tower-h2-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#28c601909f5268d7fc042184a08f254e661e7c4a"
+source = "git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service#cf5f5a08c2c69448d22f47436c52855747fcf74a"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
  "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)",
- "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)",
 ]
 
 [[package]]
@@ -1373,14 +1350,6 @@ dependencies = [
 name = "tower-service"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower?branch=eliza/generic-service#ab8a52857d4fd2b4b6f59c7e99510f99b2d9aad8"
-dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6460dff2e9969c9c998dd77558f803c770c6ea"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1735,10 +1704,8 @@ dependencies = [
 "checksum tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "028b94314065b90f026a21826cffd62a4e40a92cda3e5c069cc7b02e5945f5e9"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http?branch=eliza/generic-service)" = "<none>"
-"checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
-"checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)" = "<none>"
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?branch=eliza/generic-service)" = "<none>"
@@ -1746,7 +1713,6 @@ dependencies = [
 "checksum tower-h2-balance 0.1.0 (git+https://github.com/tower-rs/tower-h2?branch=eliza/generic-service)" = "<none>"
 "checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
-"checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower?branch=eliza/generic-service)" = "<none>"
 "checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-mpsc-lossy    = { path = "./futures-mpsc-lossy" }
 linkerd2-metrics      = { path = "./metrics" }
 linkerd2-proxy-router = { path = "./router" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.1", version = "0.1.1" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "eliza/generic-service" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -48,17 +48,17 @@ tokio = "0.1.7"
 tokio-signal = "0.2"
 tokio-timer = "0.2.4"   # for tokio_timer::clock
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
-tower-add-origin      = { git = "https://github.com/tower-rs/tower-http" }
-tower-balance         = { git = "https://github.com/tower-rs/tower" }
-tower-buffer          = { git = "https://github.com/tower-rs/tower" }
-tower-discover        = { git = "https://github.com/tower-rs/tower" }
-tower-in-flight-limit = { git = "https://github.com/tower-rs/tower" }
-tower-reconnect       = { git = "https://github.com/tower-rs/tower" }
-tower-service         = { git = "https://github.com/tower-rs/tower" }
-tower-util            = { git = "https://github.com/tower-rs/tower" }
-tower-h2              = { git = "https://github.com/tower-rs/tower-h2" }
-tower-h2-balance      = { git = "https://github.com/tower-rs/tower-h2" }
-tower-grpc            = { git = "https://github.com/tower-rs/tower-grpc" }
+tower-add-origin      = { git = "https://github.com/tower-rs/tower-http", branch = "eliza/generic-service" }
+tower-balance         = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-buffer          = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-discover        = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-in-flight-limit = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-reconnect       = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-service         = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-util            = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
+tower-h2-balance      = { git = "https://github.com/tower-rs/tower-h2", branch = "eliza/generic-service" }
+tower-h2              = { git = "https://github.com/tower-rs/tower-h2", branch = "eliza/generic-service" }
+tower-grpc            = { git = "https://github.com/tower-rs/tower-grpc", branch = "eliza/generic-service" }
 
 # dns
 trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns" }
@@ -79,7 +79,7 @@ procinfo = "0.4.2"
 net2 = "0.2"
 quickcheck = { version = "0.6", default-features = false }
 linkerd2-metrics = { path = "./metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.1", version = "0.1.1", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "eliza/generic-service", features = ["arbitrary"] }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dependencies]
 futures = "0.1"
 indexmap = "1.0.0"
-tower-service = { git = "https://github.com/tower-rs/tower" }
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -31,7 +31,7 @@ use conditional::Conditional;
 use super::{ActiveQuery, DestinationServiceQuery, UpdateRx};
 
 /// Holds the state of a single resolution.
-pub(super) struct DestinationSet<T: HttpService<ResponseBody = RecvBody>> {
+pub(super) struct DestinationSet<T: HttpService<BoxBody, ResponseBody = RecvBody>> {
     pub addrs: Exists<Cache<SocketAddr, Metadata>>,
     pub query: DestinationServiceQuery<T>,
     pub dns_query: Option<IpAddrListFuture>,
@@ -42,7 +42,7 @@ pub(super) struct DestinationSet<T: HttpService<ResponseBody = RecvBody>> {
 
 impl<T> DestinationSet<T>
 where
-    T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>,
+    T: HttpService<BoxBody, ResponseBody = RecvBody>,
     T::Error: fmt::Debug,
 {
     pub(super) fn reset_dns_query(
@@ -179,7 +179,7 @@ where
     }
 }
 
-impl<T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
+impl<T: HttpService<BoxBody, ResponseBody = RecvBody>> DestinationSet<T> {
 
     /// Returns `true` if the authority that created this query _should_ query
     /// the Destination service, but was unable to due to insufficient capaacity.

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -156,9 +156,9 @@ pub fn new(
 
 impl Resolver {
     /// Start watching for address changes for a certain authority.
-    pub fn resolve<N>(&self, authority: &DnsNameAndPort, new_endpoint: N) -> Resolution<N>
+    pub fn resolve<N, R>(&self, authority: &DnsNameAndPort, new_endpoint: N) -> Resolution<N>
     where
-        N: NewClient,
+        N: NewClient<R>,
     {
         trace!("resolve; authority={:?}", authority);
         let (update_tx, update_rx) = mpsc::unbounded();
@@ -187,14 +187,13 @@ impl Resolver {
 
 // ==== impl Resolution =====
 
-impl<N> Discover for Resolution<N>
+impl<N, R> Discover<R> for Resolution<N>
 where
-    N: NewClient<Target = Endpoint>,
+    N: NewClient<R, Target = Endpoint>,
 {
     type Key = SocketAddr;
-    type Request = <N::Client as Service>::Request;
-    type Response = <N::Client as Service>::Response;
-    type Error = <N::Client as Service>::Error;
+    type Response = <N::Client as Service<R>>::Response;
+    type Error = <N::Client as Service<R>>::Error;
     type Service = N::Client;
     type DiscoverError = ();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ where
         // Setup the public listener. This will listen on a publicly accessible
         // address and listen for inbound connections that should be forwarded
         // to the managed application (private destination).
-        let inbound: drain::Watching<_, _> = {
+        let inbound = {
             let ctx = ctx::Proxy::Inbound;
             let bind = bind.clone().with_ctx(ctx);
             let default_addr = config.private_forward.map(|a| a.into());

--- a/src/map_err.rs
+++ b/src/map_err.rs
@@ -8,10 +8,10 @@ use http::header::CONTENT_LENGTH;
 use tower_service::Service;
 
 /// Map an HTTP service's error to an appropriate 500 response.
-pub struct MapErr<T, E, F> {
+pub struct MapErr<T, E, F, R> {
     inner: T,
     f: Arc<F>,
-    _p: PhantomData<E>,
+    _p: PhantomData<(E, R)>,
 }
 
 /// Catches errors from the inner future and maps them to 500 responses.
@@ -24,7 +24,7 @@ pub struct ResponseFuture<T, E, F> {
 
 // ===== impl MapErr =====
 
-impl<T, E, F, R> MapErr<T, E, F>
+impl<T, E, F, R> MapErr<T, E, F, R>
 where
     T: Service<R, Error = E>,
     F: Fn(E) -> http::StatusCode,
@@ -39,7 +39,7 @@ where
     }
 }
 
-impl<T, B, E, F, R> Service<R> for MapErr<T, E, F>
+impl<T, B, E, F, R> Service<R> for MapErr<T, E, F, R>
 where
     T: Service<R, Response = http::Response<B>, Error = E>,
     B: Default,

--- a/src/svc/mod.rs
+++ b/src/svc/mod.rs
@@ -23,7 +23,7 @@
 
 pub use tower_service::Service;
 
-pub trait NewClient {
+pub trait NewClient<R> {
 
     /// Describes a resource to which the client will be attached.
     ///
@@ -45,7 +45,7 @@ pub trait NewClient {
     /// `Service::call` must not be called until `Service::poll_ready` returns
     /// `Async::Ready`. When `Service::poll_ready` returns an error, the
     /// client must be discarded.
-    type Client: Service;
+    type Client: Service<R>;
 
     /// Creates a client
     ///

--- a/src/telemetry/http/sensors.rs
+++ b/src/telemetry/http/sensors.rs
@@ -63,7 +63,7 @@ impl Sensors {
         A: Body + 'static,
         B: Body + 'static,
         N: NewService<
-            Request = Request<RequestBody<A>>,
+            Request<RequestBody<A>>,
             Response = Response<B>,
             Error = ClientError
         >

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -73,11 +73,10 @@ impl<T> Timeout<T> {
     }
 }
 
-impl<S, T, E> Service for Timeout<S>
+impl<S, T, E, R> Service<R> for Timeout<S>
 where
-    S: Service<Response=T, Error=E>,
+    S: Service<R, Response=T, Error=E>,
 {
-    type Request = S::Request;
     type Response = T;
     type Error = TimeoutError<E>;
     type Future = Timeout<Deadline<S::Future>>;
@@ -86,7 +85,7 @@ where
         self.inner.poll_ready().map_err(|e| self.error(e))
     }
 
-    fn call(&mut self, req: Self::Request) -> Self::Future {
+    fn call(&mut self, req: R) -> Self::Future {
         let duration = self.duration;
         let deadline = Instant::now() + duration;
         let inner = Deadline::new(self.inner.call(req), deadline);

--- a/src/tower_fn.rs
+++ b/src/tower_fn.rs
@@ -5,10 +5,10 @@ pub struct NewServiceFn<T> {
     f: T,
 }
 
-impl<T, N> NewServiceFn<T>
+impl<T, N, R> NewServiceFn<T>
 where
     T: Fn() -> N,
-    N: Service,
+    N: Service<R>,
 {
     pub fn new(f: T) -> Self {
         NewServiceFn {
@@ -17,12 +17,11 @@ where
     }
 }
 
-impl<T, N> NewService for NewServiceFn<T>
+impl<T, N, R> NewService<R> for NewServiceFn<T>
 where
     T: Fn() -> N,
-    N: Service,
+    N: Service<R>,
 {
-    type Request = N::Request;
     type Response = N::Response;
     type Error = N::Error;
     type Service = N;

--- a/src/tower_fn.rs
+++ b/src/tower_fn.rs
@@ -5,10 +5,9 @@ pub struct NewServiceFn<T> {
     f: T,
 }
 
-impl<T, N, R> NewServiceFn<T>
+impl<T, N> NewServiceFn<T>
 where
     T: Fn() -> N,
-    N: Service<R>,
 {
     pub fn new(f: T) -> Self {
         NewServiceFn {

--- a/src/transparency/client.rs
+++ b/src/transparency/client.rs
@@ -143,7 +143,7 @@ where
     }
 }
 
-impl<C, E, B> NewService for Client<C, E, B>
+impl<C, E, B> NewService<bind::HttpRequest<B>> for Client<C, E, B>
 where
     C: Connect + Clone + Send + Sync + 'static,
     C::Future: Send + 'static,
@@ -154,7 +154,6 @@ where
     B: tower_h2::Body + Send + 'static,
    <B::Data as IntoBuf>::Buf: Send + 'static,
 {
-    type Request = bind::HttpRequest<B>;
     type Response = http::Response<HttpBody>;
     type Error = Error;
     type InitError = tower_h2::client::ConnectError<C::Error>;
@@ -205,7 +204,7 @@ where
     }
 }
 
-impl<C, E, B> Service for ClientService<C, E, B>
+impl<C, E, B> Service<bind::HttpRequest<B>> for ClientService<C, E, B>
 where
     C: Connect + Send + Sync + 'static,
     C::Connected: Send,
@@ -216,7 +215,6 @@ where
     B: tower_h2::Body + Send + 'static,
    <B::Data as IntoBuf>::Buf: Send + 'static,
 {
-    type Request = bind::HttpRequest<B>;
     type Response = http::Response<HttpBody>;
     type Error = Error;
     type Future = ClientServiceFuture;
@@ -228,7 +226,7 @@ where
         }
     }
 
-    fn call(&mut self, req: Self::Request) -> Self::Future {
+    fn call(&mut self, req: bind::HttpRequest<B>) -> Self::Future {
         debug!("client request: method={} uri={} version={:?} headers={:?}",
             req.method(), req.uri(), req.version(), req.headers());
         match self.inner {

--- a/src/transparency/orig_proto.rs
+++ b/src/transparency/orig_proto.rs
@@ -53,11 +53,10 @@ impl<S> Upgrade<S> {
     }
 }
 
-impl<S, B1, B2> Service for Upgrade<S>
+impl<S, B1, B2> Service<http::Request<B1>> for Upgrade<S>
 where
-    S: Service<Request = http::Request<B1>, Response = http::Response<B2>>,
+    S: Service<http::Request<B1>, Response = http::Response<B2>>,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;
     type Future = future::Map<
@@ -69,7 +68,7 @@ where
         self.inner.poll_ready()
     }
 
-    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+    fn call(&mut self, mut req: http::Request<B1>) -> Self::Future {
         let mut downgrade_response = false;
 
         if self.upgrade_h1 && req.version() != http::Version::HTTP_2 {
@@ -133,11 +132,10 @@ where
     }
 }
 
-impl<S, B1, B2> NewService for Upgrade<S>
+impl<S, B1, B2> NewService<http::Request<B1>> for Upgrade<S>
 where
-    S: NewService<Request = http::Request<B1>, Response = http::Response<B2>>,
+    S: NewService<http::Request<B1>, Response = http::Response<B2>>,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;
     type Service = Upgrade<S::Service>;
@@ -170,11 +168,10 @@ impl<S> Downgrade<S> {
     }
 }
 
-impl<S, B1, B2> Service for Downgrade<S>
+impl<S, B1, B2> Service<http::Request<B1>> for Downgrade<S>
 where
-    S: Service<Request = http::Request<B1>, Response = http::Response<B2>>,
+    S: Service<http::Request<B1>, Response = http::Response<B2>>,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;
     type Future = future::Map<
@@ -186,7 +183,7 @@ where
         self.inner.poll_ready()
     }
 
-    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+    fn call(&mut self, mut req: http::Request<B1>) -> Self::Future {
         let mut upgrade_response = false;
 
         if req.version() == http::Version::HTTP_2 {

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -29,7 +29,7 @@ use super::tcp;
 /// service.
 pub struct Server<S, B, G>
 where
-    S: NewService<Request=http::Request<HttpBody>>,
+    S: NewService<http::Request<HttpBody>>,
     S::Future: 'static,
     B: tower_h2::Body,
 {
@@ -53,12 +53,12 @@ where
 impl<S, B, G> Server<S, B, G>
 where
     S: NewService<
-        Request = http::Request<HttpBody>,
+        http::Request<HttpBody>,
         Response = http::Response<B>
     > + Clone + Send + 'static,
     S::Future: 'static,
-    <S as NewService>::Service: Send,
-    <<S as NewService>::Service as ::tower_service::Service>::Future: Send,
+    <S as NewService<http::Request<HttpBody>>>::Service: Send,
+    <<S as NewService<http::Request<HttpBody>>>::Service as ::tower_service::Service<http::Request<HttpBody>>>::Future: Send,
     S::InitError: fmt::Debug,
     S::Future: Send + 'static,
     B: tower_h2::Body + 'static,

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -322,8 +322,7 @@ impl Svc {
     }
 }
 
-impl Service for Svc {
-    type Request = Request<RecvBody>;
+impl Service<Request<RecvBody>> for Svc {
     type Response = Response<RspBody>;
     type Error = h2::Error;
     type Future = Box<Future<Item=Self::Response, Error=Self::Error> + Send>;
@@ -332,7 +331,7 @@ impl Service for Svc {
         Ok(Async::Ready(()))
     }
 
-    fn call(&mut self, req: Self::Request) -> Self::Future {
+    fn call(&mut self, req: Request<RecvBody>) -> Self::Future {
         let req = req.map(|body| {
             assert!(body.is_end_stream(), "h2 test server doesn't support request bodies yet");
             Box::new(futures::stream::empty()) as ReqBody
@@ -373,8 +372,7 @@ impl hyper::service::Service for Svc {
 #[derive(Debug)]
 struct NewSvc(Arc<HashMap<String, Route>>);
 
-impl NewService for NewSvc {
-    type Request = Request<RecvBody>;
+impl NewService<Request<RecvBody>> for NewSvc {
     type Response = Response<RspBody>;
     type Error = h2::Error;
     type InitError = ::std::io::Error;


### PR DESCRIPTION
As described in tower-rs/tower#99, this tracks the prototype `tower-rs` change (hawkw/tower#1) that makes `Service::Request` into a type parameter, rather than an associated type.

This PR is not necessarily intended to be merged, but is opened to allow the changes to be discussed and reviewed more easily.